### PR TITLE
Limit use to RHEL/CentOS distros

### DIFF
--- a/.testenv/yamllint.yml
+++ b/.testenv/yamllint.yml
@@ -1,0 +1,11 @@
+---
+# -*- coding: utf-8 -*-
+
+extends: default
+
+rules:
+  line-length: disable
+  brackets: disable
+  truthy: disable
+
+# vim: set ts=2 sw=2 tw=2 :

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,17 +1,17 @@
 ---
-- name: Check if EPEL repo is already configured
+- name: check if epel repo is already configured
   stat:
     path: "{{ epel_repofile_path }}"
-  register: epel_repofile_result
+  register: epel_register_repofile
 
-- name: Import EPEL GPG key.
+- name: import epel gpg key
   rpm_key:
     key: "{{ epel_repo_gpg_key_url }}"
     state: present
-  when: not epel_repofile_result.stat.exists
+  when: not epel_register_repofile.stat.exists
   ignore_errors: "{{ ansible_check_mode }}"
 
-- name: Install EPEL repo
+- name: install epel repo
   yum_repository:
     name: "{{ epel_repo_name }}"
     file: "{{ epel_repofile_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,3 +3,4 @@
   tags:
     - 'role::epel'
     - 'role::epel:install'
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
This allows the role to be stated as dependency for e.g. [ansible-role-console](https://github.com/adfinis-sygroup/ansible-role-console), where installing packages like `htop` on at least CentOS 7 requires the EPEL repository to be enabled.

Depends on/includes #1.